### PR TITLE
Fix typed verse not saved

### DIFF
--- a/app.js
+++ b/app.js
@@ -48,7 +48,9 @@ function saveTypedVerse() {
       currentVerseText +
       '</em>';
   }
-  markDayCompleted(new Date().toISOString().split('T')[0]);
+  const today = new Date().toISOString().split('T')[0];
+  localStorage.setItem(`typed_${today}`, typed);
+  markDayCompleted(today);
 }
 
 // — REFLECTION —


### PR DESCRIPTION
## Summary
- ensure typed verse is persisted in localStorage

## Testing
- `node --check app.js`
- `node --check calendar.js`

------
https://chatgpt.com/codex/tasks/task_e_6885ebc883ec832cb011e909675283a3